### PR TITLE
Fixed aim position override not being cleared

### DIFF
--- a/Client.lua
+++ b/Client.lua
@@ -96,6 +96,10 @@ CreateThread(function()
     while true do
         Wait(config.Debug and 0 or config.CheckDelay)
         if not IsPlayerFreeAiming(PlayerId()) then
+            if overrideAimPosition then
+                overrideAimPosition = false
+                ResetHudComponentValues(14)
+            end
             goto continue
         end
         local ped = PlayerPedId()


### PR DESCRIPTION
Fixed aim position override not being cleared when unaiming.

This is noticeable when following these steps:
1. Get a gun and aim it at a location where the reticle position is altered.
2. Stop aiming.
3. Once your arm is fully down try shooting (without aiming) - you'll notice the arm stays where it is but the gun shoots towards the location where you were previously aiming at.